### PR TITLE
pre-set variables

### DIFF
--- a/fmREST.php
+++ b/fmREST.php
@@ -48,7 +48,7 @@ class fmREST {
 
 		$this->debug ('findRecords pass 1' , $result);
 		
-		if ( $result ['errorCode'] == 952 ) {
+		if ( isset($result['errorCode']) && $result ['errorCode'] == 952 ) {
 			$_COOKIE ['token']=''; 
 			$this->login();
 			$result = $this->callCURL ($url, 'POST', $criteria);
@@ -66,7 +66,7 @@ class fmREST {
 
 		$this->debug ('getRecords pass 1',$result);
 		
-		if ( $result ['errorCode'] == 952 ) {
+		if ( isset($result['errorCode']) && $result ['errorCode'] == 952 ) {
 			$_COOKIE ['token']=''; 
 			$this->login();
 			$result = $this->callCURL ($url, 'GET');			
@@ -85,7 +85,7 @@ class fmREST {
 		$this->debug ('update record data ' . $id . ': ', $record);
 		$this->debug ('editRecord ' . $id . ' pass 1', $result);
 
-		if ( $result ['errorCode'] == 952 ) {
+		if ( isset($result['errorCode']) &&  $result ['errorCode'] == 952 ) {
 			$_COOKIE ['token']=''; 
 			$this->login();
 			$result = $this->callCURL ($url, 'PUT', $record);
@@ -104,7 +104,7 @@ class fmREST {
 
 		$this->debug ('create record data : ', $record);
 		$this->debug ('createRecord pass 1', $result);
-		if ( $result ['errorCode'] == 952 ) {
+		if ( isset($result['errorCode']) &&  $result ['errorCode'] == 952 ) {
 			$_COOKIE ['token']=''; 
 			$this->login();
 			$result = $this->callCURL ($url, 'POST', $record);
@@ -122,7 +122,7 @@ class fmREST {
 
 		$this->debug ('getRecord ' . $id . ' pass 1', $result);
 
-		if ( $result ['errorCode'] == 952 ) {
+		if ( isset($result['errorCode']) &&  $result ['errorCode'] == 952 ) {
 			$_COOKIE ['token']=''; 
 			$this->login();
 			$result = $this->callCURL ($url, 'GET', $parameters);
@@ -138,7 +138,7 @@ class fmREST {
 		$result = $this->callCURL ($url, 'DELETE');
 
 		$this->debug ('deleteRecord ' . $id . ' pass 1', $result);
-		if ( $result ['errorCode'] == 952 ) {
+		if ( isset($result['errorCode']) &&  $result ['errorCode'] == 952 ) {
 			$_COOKIE ['token']=''; 
 			$this->login();
 			$result = $this->callCURL ($url, 'DELETE');
@@ -155,7 +155,7 @@ class fmREST {
 
 		$this->debug ('setGlobalFields pass 1', $result);
 
-		if ( $result ['errorCode'] == 952 ) {
+		if ( isset($result['errorCode']) && $result ['errorCode'] == 952 ) {
 			$_COOKIE ['token']=''; 
 			$this->login();
 			$result = $this->callCURL ($url, 'PUT', $fields);
@@ -167,7 +167,6 @@ class fmREST {
 	
 	function login () {		
 		$this->debug ('login start cookie',$_COOKIE);
-		
 		if (!empty ($_COOKIE['token'])) {
 			$this->debug ('login existing token', $_COOKIE['token']);
 			return (array('token'=>$_COOKIE['token'],'errorCode'=>0,'result'=>'Existing')); 
@@ -180,16 +179,19 @@ class fmREST {
 		
 		$this->debug ('login result',$result);
 
-		$token = $result['token'];
+		if (isset ($result['token'])) {
+			$token = $result['token'];
 		
-		//using cookie: 
-			//has to be set before any content, with the header
-			//time should be refreshed each time we successfully hit a function - maybe within callCURL()
-		setcookie("token", $token, time()+(14*60), '','',true,true);  
-		$_COOKIE['token'] = $token;
+			//using cookie: 
+				//has to be set before any content, with the header
+				//time should be refreshed each time we successfully hit a function - maybe within callCURL()
+			setcookie("token", $token, time()+(14*60), '','',true,true);  
+			$_COOKIE['token'] = $token;
+		}
 
 		$this->debug ('login end cookie',$_COOKIE);								
 		return $result; //error
+
 	}	
 	
 	function logout () {

--- a/sample.php
+++ b/sample.php
@@ -1,16 +1,20 @@
 <?PHP
 
+error_reporting(E_ALL);
+ini_set('display_errors', true );
+
+if (!isset ($_REQUEST['action'])) $_REQUEST['action']='';
+$result = array();
 
 include_once ('fmREST.php');
 
-//$debug=1;
+// $debug=1;
 
 $host = 'localhost';
 $db = 'Contacts';
 $layout = 'Contacts';
-$user = 'rest';
-$pass = 'rest';
-
+$user = 'admin';
+$pass = 'paradise';
 
 $fm = new fmREST ($host, $db, $layout, $user, $pass);
 
@@ -66,6 +70,7 @@ elseif ($_REQUEST['action'] == 'deleterecord') {
 <html>
 <head>
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+<title>fmREST.php</title>
 </head>
 <body>
 <div style="margin: 50px;">
@@ -87,7 +92,7 @@ elseif ($_REQUEST['action'] == 'deleterecord') {
 			  <input type="radio" name="action" value="deleterecord" > Delete Record<br>
 			  <input type="radio" name="action" value="getrecord" > Get Record<br>
 			  <input type="radio" name="action" value="getrecords" > Get Records<br>
-			  <input type="radio" name="action" value="getrecords" > Get Records<br>
+			  <input type="radio" name="action" value="findrecords" > Find Records<br>
 			  <input type="radio" name="action" value="editrecord" > Edit Record<br>
 			  <!--input type="radio" name="action" value="setglobal" > Set Global<br-->
 			<br/>
@@ -99,12 +104,12 @@ elseif ($_REQUEST['action'] == 'deleterecord') {
 
 Request:
 <pre>
-	<? print_r ($_REQUEST); ?>
+	<?PHP print_r ($_REQUEST); ?>
 </pre>
 
 Result:
 <pre>
-	<? print_r ($result); ?>
+	<?PHP print_r ($result); ?>
 </pre>
 </body>
 </html>


### PR DESCRIPTION
FMS16 on Windows requires all variables be pre-set or checked for their existence or they will throw an error 500. On other installations, depending on server configurations, unnecessary errors will show.

Added pre-set variables in the sample file and added checks for their existence in fmREST.php class, so these files should now run without error on all platforms.